### PR TITLE
Modify --help to show default locations for config files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ see `--help`, but, generally:
 
 ```
 Usage iblox <Facility (dns|dhcp)> <action>(add|update|delete) [options]
-    -c /path/to/infoblox.yaml,       use custom config path (~/.infoblox.yaml, /etc/infoblox.yaml)
+    -c /path/to/infoblox.yaml,       use custom config path (defaults: ~/.iblox.yaml, /etc/iblox.yaml)
         --config
     -f, --fqdn FQDN                  FQDN or add/update/remove
     -h, --new-fqdn FQDN              New FQDN if updating a record

--- a/bin/iblox
+++ b/bin/iblox
@@ -11,7 +11,7 @@ options = Hash.new
 
 OptionParser.new do |opts|
   opts.banner = "Usage iblox <Facility (dns|dhcp)> <action>(add|update|delete) [options]"
-  opts.on("-c", "--config /path/to/infoblox.yaml",String, "use custom config path (~/.infoblox.yaml, /etc/infoblox.yaml)") do |config |
+  opts.on("-c", "--config /path/to/infoblox.yaml",String, "use custom config path (defaults: ~/.iblox.yaml, /etc/iblox.yaml)") do |config |
     options.merge!(Hash[YAML::load(open(config)).map { |k, v| [k.to_sym, v] }])
     options[:config] = config
   end


### PR DESCRIPTION
It is convenient to have these paths available at the command line without needing to look up the README in the repo or in the code.
